### PR TITLE
Fix blockquote text contrast in light and dark mode

### DIFF
--- a/Shared/Sources/MarkdownRenderer/Resources/modern.css
+++ b/Shared/Sources/MarkdownRenderer/Resources/modern.css
@@ -83,7 +83,7 @@ blockquote,
 }
 blockquote > :last-child,
 .markdown-alert > :last-child { margin-bottom: 0; }
-blockquote { color: var(--text-muted); }
+blockquote { color: var(--text); }
 
 /* Code */
 code {


### PR DESCRIPTION
## Summary

- Blockquote text was styled with `--text-muted`, giving poor contrast against the `--bg-alt` background in both light and dark mode
- Changed to `--text` so blockquotes are legible in both appearance modes
- The left border and `--bg-alt` background still visually distinguish blockquotes

Closes #10

## Test plan

- [ ] Open a markdown file with blockquotes in light mode — text should be clearly readable
- [ ] Switch to dark mode — text should still be clearly readable
- [ ] Confirm blockquotes still look visually distinct from body text (left border + alt background)

🤖 Generated with [Claude Code](https://claude.com/claude-code)